### PR TITLE
DASH-1242 Logged in users condition added to users data source.

### DIFF
--- a/classes/local/data_grid/filter/online_users_condition.php
+++ b/classes/local/data_grid/filter/online_users_condition.php
@@ -1,0 +1,72 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Filters results to currently logged in (online) users.
+ *
+ * Mirrors the logic used by Moodle core's block_online_users: a user is
+ * considered online when their lastaccess is more recent than the configured
+ * timeframe (block_online_users_timetosee, default 5 minutes).
+ *
+ * @package    block_dash
+ * @copyright  2026 bdecent gmbh <https://bdecent.de>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace block_dash\local\data_grid\filter;
+
+/**
+ * Filters results to currently logged in (online) users.
+ *
+ * @package block_dash
+ */
+class online_users_condition extends condition {
+    /**
+     * Return the lower bound timestamp for u.lastaccess.
+     *
+     * Matches block_online_users: timefrom = 100 * floor((now - timetoshowusers) / 100),
+     * where timetoshowusers comes from $CFG->block_online_users_timetosee (minutes),
+     * falling back to 5 minutes when the setting is not present.
+     *
+     * @return array
+     */
+    public function get_values() {
+        global $CFG;
+
+        $timetoshowusers = 300;
+        if (isset($CFG->block_online_users_timetosee)) {
+            $timetoshowusers = (int) $CFG->block_online_users_timetosee * 60;
+        }
+        $now = time();
+        $timefrom = 100 * (int) floor(($now - $timetoshowusers) / 100);
+
+        return [$timefrom];
+    }
+
+    /**
+     * Get filter label.
+     *
+     * @return string
+     * @throws \coding_exception
+     */
+    public function get_label() {
+        if ($label = parent::get_label()) {
+            return $label;
+        }
+
+        return get_string('loggedinusers', 'block_dash');
+    }
+}

--- a/classes/local/data_source/users_data_source.php
+++ b/classes/local/data_source/users_data_source.php
@@ -37,6 +37,7 @@ use block_dash\local\data_grid\filter\logged_in_user_condition;
 use block_dash\local\data_grid\filter\filter_collection;
 use block_dash\local\data_grid\filter\filter_collection_interface;
 use block_dash\local\data_grid\filter\my_groups_condition;
+use block_dash\local\data_grid\filter\online_users_condition;
 use block_dash\local\data_grid\filter\participants_condition;
 use block_dash\local\data_grid\filter\user_field_filter;
 use block_dash\local\data_grid\filter\user_profile_field_filter;
@@ -164,6 +165,10 @@ class users_data_source extends abstract_data_source {
         $filtercollection->add_filter(new participants_condition('participants', 'u.id'));
         $filtercollection->add_filter(new my_groups_condition('my_groups', 'gm300.groupid'));
         $filtercollection->add_filter(new current_course_condition('current_course', 'c.id'));
+
+        $onlineusers = new online_users_condition('online_users', 'u.lastaccess');
+        $onlineusers->set_operation(filter::OPERATION_GREATER_THAN);
+        $filtercollection->add_filter($onlineusers);
 
         if (block_dash_has_pro()) {
             $filtercollection->add_filter(new \local_dash\data_grid\filter\relations_role_condition('parentrole', 'u.id'));

--- a/lang/en/block_dash.php
+++ b/lang/en/block_dash.php
@@ -717,6 +717,7 @@ $string['lefttop'] = "Left Top";
 $string['like_item'] = 'Like item';
 $string['like_item_help'] = 'Make the details area the same size as the card.';
 $string['loggedinuser'] = 'Logged in user';
+$string['loggedinusers'] = 'Logged in users';
 $string['loginstreakdays'] = 'Login streak days';
 $string['loginstreakdaysdesc'] = 'Set the number of consecutive days required to maintain a streak.';
 $string['lowerthan'] = 'Lower than';


### PR DESCRIPTION
Adds an online_users_condition that filters the Users data source to users considered online — same logic as core block_online_users (u.lastaccess > now - $CFG->block_online_users_timetosee, default 5 minutes). No additional plugin settings; reuses the core admin setting.