### PR TITLE
Only initialise filters that are actually used

### DIFF
--- a/classes/local/data_grid/filter/filter.php
+++ b/classes/local/data_grid/filter/filter.php
@@ -169,6 +169,28 @@ class filter implements filter_interface {
     }
 
     /**
+     * Whether this filter needs to be initialised for the current request.
+     *
+     * Initialising a filter loads its list of available options, which can be an
+     * expensive operation (e.g. one query per option). A block only ever uses a
+     * filter when it is enabled in the block configuration, when it carries a
+     * value (or default value) that contributes to the query, when it is required,
+     * or when it is a condition (always applied). Every other filter in the
+     * collection would have its loaded options discarded, so there is no point
+     * initialising it.
+     *
+     * @return bool
+     */
+    public function should_initialise(): bool {
+        $preferences = $this->get_preferences();
+        return $this->is_applied()
+            || $this->is_required()
+            || $this->has_raw_value()
+            || $this->has_default_raw_value()
+            || !empty($preferences['enabled']);
+    }
+
+    /**
      * Set if filter is required.
      *
      * @param bool $required

--- a/classes/local/data_grid/filter/filter_collection.php
+++ b/classes/local/data_grid/filter/filter_collection.php
@@ -70,6 +70,11 @@ class filter_collection implements filter_collection_interface {
      */
     public function init() {
         foreach ($this->get_filters() as $filter) {
+            // Skip filters that are not used in this request to avoid loading
+            // (and then discarding) their options. See filter::should_initialise().
+            if (!$filter->should_initialise()) {
+                continue;
+            }
             $filter->init();
         }
     }

--- a/classes/local/data_source/abstract_data_source.php
+++ b/classes/local/data_source/abstract_data_source.php
@@ -335,8 +335,9 @@ abstract class abstract_data_source implements data_source_interface, \templatab
     final public function get_filter_collection() {
         if (is_null($this->filtercollection)) {
             $this->filtercollection = $this->build_filter_collection();
-            $this->filtercollection->init();
 
+            // Apply saved filter preferences before init() so that init() can skip
+            // filters that are not enabled (avoids loading options that are never used).
             if ($this->get_preferences('filters')) {
                 foreach ($this->get_preferences('filters') as $filtername => $filterpreferences) {
                     if (is_array($filterpreferences) || is_object($filterpreferences)) {
@@ -346,6 +347,8 @@ abstract class abstract_data_source implements data_source_interface, \templatab
                     }
                 }
             }
+
+            $this->filtercollection->init();
         }
 
         return $this->filtercollection;


### PR DESCRIPTION
## Summary

Dash blocks initialise **every** filter in their filter collection on each render — even filters that are not enabled and whose options are never shown. Because a filter's `init()` loads its list of available options (which for some filters is an expensive per-option query), a dashboard with **zero filters enabled** still paid the full cost of loading and then discarding every filter's options.

On a customer site (~2,000 users, ~3,500 role assignments) this caused a single "Role assignments" dashboard page to issue **~19,000 DB reads** with no filters configured at all. After this change that page drops to **~400 reads**.

This is a framework-level fix in `block_dash` and benefits **every** dash block, not just the role assignments addon. It is paired with a companion PR in `local_dash` that makes the three offending role-assignment filters cheap even when they *are* enabled.

## Root cause

`abstract_data_source::get_filter_collection()` did this, in order:

1. `build_filter_collection()` — construct all filter objects
2. `filter_collection->init()` — **init every filter** (loads options)
3. apply saved filter preferences (the `enabled` flag) to each filter

So `init()` always ran for all filters, *before* the code even knew which filters were enabled. `filter_collection::init()` had no notion of "is this filter used":

```php
public function init() {
    foreach ($this->get_filters() as $filter) {
        $filter->init();   // unconditional
    }
}
```

## Change

1. **Reorder** `get_filter_collection()` to apply saved filter preferences **before** `init()`, so the enabled state is known at init time.
2. **Add `filter::should_initialise()`** — returns true only when the filter is actually used this request:
   - it is a condition (always applied — `condition::is_applied()` is always true),
   - it is required,
   - it carries a raw value or a default raw value (i.e. it contributes to the query via `get_filters_with_values()`),
   - or it is enabled in the block configuration.
3. **Gate `filter_collection::init()`** on `should_initialise()`.

### Why these conditions are safe

- `get_sql_and_params()` only ever uses `get_filters_with_values()` (filters with a raw/default value). `should_initialise()` is a superset of that set, so every filter that can contribute SQL is still initialised.
- Conditions are always applied and always have a raw value, so they always initialise.
- The filter-configuration form lists filters via `get_label()`, not `init()`, so unenabled filters still appear in the editor.
- The only production caller of `filter_collection::init()` is `get_filter_collection()` (verified across `blocks/dash` and `local/dash`); all other code reaches filters through that accessor, which now sets preferences first.

## Files

- `classes/local/data_grid/filter/filter.php` — new `should_initialise()`
- `classes/local/data_grid/filter/filter_collection.php` — gate `init()`
- `classes/local/data_source/abstract_data_source.php` — apply preferences before `init()`

## Measurements (live customer-like dataset: 3,521 role assignments, 264 distinct contexts, 9 roles, 1,170 users)

| Stage (role assignments dashboard, no filters enabled) | Before | After |
|---|---:|---:|
| `get_filter_collection()` + `init()` | 18,739 reads | **0 reads** |
| Full block render (`get_block_content`) | ~19,126 reads | **~401 reads** |

## Risk / review notes

- Behaviour change: filters that are not enabled/applied are no longer initialised. If any downstream code assumed *all* filters are always initialised (regardless of enabled state), it would need to call `init()` explicitly. None found in `blocks/dash` or `local/dash`.
- Suggest running the `blocks/dash` filter unit tests (`filter_test.php`) and a manual check that enabling a filter on a block still renders its dropdown with options.

## Testing done

- PHP lint on all three files.
- Reproduced and measured the read counts before/after with a read-only CLI harness against a copy of the customer dataset.
